### PR TITLE
入力済テキスト・変換候補テキストの表示における いわゆる中華フォント問題を解消

### DIFF
--- a/azooEditor/ContentView.swift
+++ b/azooEditor/ContentView.swift
@@ -21,6 +21,7 @@ struct ContentView: View {
     @State private var imeState = true
     @State private var deleteTask: Task<Void, any Error>?
     @FocusState private var textFieldFocus
+    private let typesettingLanguage = TypesettingLanguage.explicit(.init(languageCode: .japanese, script: .japanese, region: .japan))
     private static let option = ConvertRequestOptions(
         requireJapanesePrediction: false,
         requireEnglishPrediction: false,
@@ -67,6 +68,7 @@ struct ContentView: View {
             } label: {
                 Text(candidates[index].text)
                     .font(.largeTitle)
+                    .typesettingLanguage(typesettingLanguage)
                     .bold(selection == index)
                     .underline(selection == index)
                     .padding()
@@ -219,6 +221,7 @@ struct ContentView: View {
                 Divider()
                 (Text(result) + Text(composingText.convertTarget).underline())
                     .font(.largeTitle)
+                    .typesettingLanguage(typesettingLanguage)
                 HStack(spacing: 20) {
                     Button("Copy and Claer", systemImage: "doc.on.doc") {
                         UIPasteboard.general.string = result


### PR DESCRIPTION
visionOS における日本語入力補助アプリケーションとしてのリリース、おめでとうございます！

https://x.com/mnishi41/status/1754706014639907163 でのフィードバックを拝見し、日本語テキストが表示される部分におけるいわゆる中華フォント問題を解消する提案をさせていただきたいと思います。

|Before|After|
|:-:|:-:|
|![スクリーンショット 2024-02-06 13 22 17](https://github.com/nyanko3141592/azooEditor/assets/13805382/56cc8aee-91fe-488e-800c-688a8c8d0ed3)|![スクリーンショット 2024-02-06 13 25 18](https://github.com/nyanko3141592/azooEditor/assets/13805382/0f885767-3092-421d-9c80-1f9e092f0070)|

日本語テキストが表示される部分において [`typesettingLanguage(_:isEnabled:)`](https://developer.apple.com/documentation/swiftui/text/typesettinglanguage(_:isenabled:)-85e9h) を指定することで解消を図ります。